### PR TITLE
Specifying tc2_mc2.ST_AxisStatus and adding colons to blank switch cases to suppress warnings

### DIFF
--- a/POUs/Motion/FB_DriveVirtual.TcPOU
+++ b/POUs/Motion/FB_DriveVirtual.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4020.14">
+<TcPlcObject Version="1.1.0.1">
   <POU Name="FB_DriveVirtual" Id="{45901cd0-c6d2-4114-b7cf-de832171219f}" SpecialFunc="None">
     <Declaration><![CDATA[///#########################################################
 ///Function block to run a virtual drive with Nc
@@ -57,7 +57,7 @@ VAR_OUTPUT
 	bHomed: BOOL;
 	nErrorId: UDINT;
 	nMotionAxisID:UDINT:=0;  //Axis id in Motion (NC)
-	Status: ST_AxisStatus;
+	Status: tc2_mc2.ST_AxisStatus;
 	fActVelocity: LREAL;
 	fActPosition: LREAL;
 	fActDiff: LREAL;

--- a/POUs/Motion/FB_NcAxis.TcPOU
+++ b/POUs/Motion/FB_NcAxis.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.10">
+<TcPlcObject Version="1.1.0.1">
   <POU Name="FB_NcAxis" Id="{0e6f3299-5a2e-4431-8f09-1233c54c1e17}" SpecialFunc="None">
     <Declaration><![CDATA[///#########################################################
 ///Function block to communicate between Nc and Plc.
@@ -24,7 +24,7 @@ END_VAR
 VAR_OUTPUT
 	EnO: BOOL;
 	bError: BOOL;
-	Status: ST_AxisStatus;
+	Status: tc2_mc2.ST_AxisStatus;
 END_VAR
 VAR
 	Axis: AXIS_REF;

--- a/POUs/Motion/Homing/FB_HomeVirtual.TcPOU
+++ b/POUs/Motion/Homing/FB_HomeVirtual.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.10">
+<TcPlcObject Version="1.1.0.1">
   <POU Name="FB_HomeVirtual" Id="{a69b16ef-d088-4494-bcb3-4c391e3a9c2d}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_HomeVirtual
 VAR_INPUT
@@ -71,10 +71,15 @@ IF fbExecuteRiseEdge.Q THEN
   //Check if valid nCmdDataLocal
   CASE nCmdDataLocal OF  	
     1:
+		;
     2:
+		;
     3:
+		;
     4:
+		;
     15:
+		;
     ELSE //nCmdData not valid	
       bError:=TRUE;
       nErrorId:=16#4FFF;   
@@ -384,7 +389,16 @@ RETURN;]]></ST>
       <LineId Id="646" Count="0" />
       <LineId Id="648" Count="0" />
       <LineId Id="647" Count="0" />
-      <LineId Id="651" Count="4" />
+      <LineId Id="1559" Count="0" />
+      <LineId Id="651" Count="0" />
+      <LineId Id="1560" Count="0" />
+      <LineId Id="652" Count="0" />
+      <LineId Id="1561" Count="0" />
+      <LineId Id="653" Count="0" />
+      <LineId Id="1562" Count="0" />
+      <LineId Id="654" Count="0" />
+      <LineId Id="1563" Count="0" />
+      <LineId Id="655" Count="0" />
       <LineId Id="658" Count="1" />
       <LineId Id="650" Count="0" />
       <LineId Id="100" Count="0" />


### PR DESCRIPTION
Needed before an update to the motion library